### PR TITLE
Use octal for literals in executable.

### DIFF
--- a/executable.js
+++ b/executable.js
@@ -1,5 +1,5 @@
 module.exports = function (process, stat) {
-    if (stat.mode & 001) return true
+    if (stat.mode & 01) return true
     if (stat.uid == process.getuid() && stat.mode & 010) return true
     if (process.getgroups && process.getgroups().some(function (gid) {
         return gid == stat.gid

--- a/t/proof/executable.t.js
+++ b/t/proof/executable.t.js
@@ -14,11 +14,11 @@ require('../..')(5, function (assert) {
         }
     }
 
-    assert(executable(null, { mode: 001 }), 'other execute')
+    assert(executable(null, { mode: 01 }), 'other execute')
     assert(executable(process, { mode: 010, uid: 700 }), 'uid execute')
     assert(executable(process, { mode: 0100, gid: 33 }), 'groups execute')
     assert(executable(process, { mode: 0100, gid: 10 }), 'gid execute')
-    assert(!executable(process, { mode: 002, gid: 19 }), 'cannot execute')
+    assert(!executable(process, { mode: 02, gid: 19 }), 'cannot execute')
 
 // LESSON:
     // what is a bit mask?


### PR DESCRIPTION
Changed permissions from hexadecimal to octal. 
