### PR TITLE
Test Node.JS 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
+  - '4.0.0'
+  - '4.1.0'
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 
 language: node_js
 
+# test node.js versions available via nvm
 node_js:
   - '0.10'
   - '0.12'


### PR DESCRIPTION
4.0.0 and 4.1.0 are available through `nvm` at this instant, so that's what we want to test. 

Closes #290 .
